### PR TITLE
Testing: Build support for fms-io-dev

### DIFF
--- a/.testing/Makefile
+++ b/.testing/Makefile
@@ -21,7 +21,7 @@ MKMF := $(abspath $(DEPS)/mkmf/bin/mkmf)
 
 # FMS framework
 FMS_URL ?= https://github.com/NOAA-GFDL/FMS.git
-FMS_COMMIT ?= f2e2c86f6c0eb6d389a20509a8a60fa22924e16b
+FMS_COMMIT ?= fms-io-dev
 FMS := $(DEPS)/fms
 
 #---
@@ -110,7 +110,7 @@ $(BUILD)/%/Makefile: $(BUILD)/%/path_names
 	cp $(MKMF_TEMPLATE) $(@D)
 	cd $(@D) && $(MKMF) \
 		-t $(notdir $(MKMF_TEMPLATE)) \
-		-o '-I $(FMS)/build' \
+		-o '-I $(FMS)/build -I $(FMS)/src/include' \
 		-p MOM6 \
 		-l '$(FMS)/lib/libfms.a' \
 		-c $(MKMF_CPP) \


### PR DESCRIPTION
This patch modifies the Makefile to enable local builds of the test suite.  This includes an explict include path to fms_platform.h.

The include path will need to be added to dev/gfdl at some point; for now this is just to help facilitate testing of fms-io-dev

I am finding some build problems with the intrinsic topographies ("spoon", etc) but we can go over those some time tomorrow.